### PR TITLE
Update favicon and logo size

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,8 +9,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&amp;display=swap" rel="stylesheet">
   <meta name="description" content="Sorry, the page you are looking for doesn’t exist.">
-  <link rel="icon" type="image/png" href="assets/Secondary%20Logo%20or%20Alternate%20Logo.png">
-  <link rel="apple-touch-icon" href="assets/Primary%20Logo%20or%20Full%20Logo.png">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
+  <link rel="apple-touch-icon" href="assets/logo.svg">
   <link rel="manifest" href="site.webmanifest">
   <meta property="og:image" content="assets/Primary%20Logo%20or%20Full%20Logo.png">
   <meta name="twitter:card" content="summary_large_image">

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&amp;display=swap" rel="stylesheet">
   <meta name="description" content="Theo’s Detailing offers professional mobile car detailing that brings the shine to you.">
-  <link rel="icon" type="image/png" href="assets/Secondary%20Logo%20or%20Alternate%20Logo.png">
-  <link rel="apple-touch-icon" href="assets/Primary%20Logo%20or%20Full%20Logo.png">
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
+  <link rel="apple-touch-icon" href="assets/logo.svg">
   <link rel="manifest" href="site.webmanifest">
   <meta property="og:image" content="assets/Primary%20Logo%20or%20Full%20Logo.png">
   <meta name="twitter:card" content="summary_large_image">

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -3,14 +3,14 @@
   "short_name": "Theo's Detailing",
   "icons": [
     {
-      "src": "/assets/Secondary%20Logo%20or%20Alternate%20Logo.png",
+      "src": "/assets/logo.svg",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/svg+xml"
     },
     {
-      "src": "/assets/Primary%20Logo%20or%20Full%20Logo.png",
+      "src": "/assets/logo.svg",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/svg+xml"
     }
   ],
   "start_url": "/",

--- a/styles.css
+++ b/styles.css
@@ -16,7 +16,7 @@ img, video {
 }
 
 .logo {
-  height: 40px;
+  height: 60px;
   width: auto;
   max-width: 100%;
 }


### PR DESCRIPTION
## Summary
- use the small `logo.svg` for favicons and web manifest icons
- bump `.logo` height to 60px so the visible logo is larger

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882c05a62308327a497912006fb26fc