### PR TITLE
Improve logo sizing and favicon

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,8 +9,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&amp;display=swap" rel="stylesheet">
   <meta name="description" content="Sorry, the page you are looking for doesn’t exist.">
-  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
-  <link rel="apple-touch-icon" href="assets/logo.svg">
+  <link rel="icon" type="image/png" href="assets/Secondary%20Logo%20or%20Alternate%20Logo.png">
+  <link rel="apple-touch-icon" href="assets/Secondary%20Logo%20or%20Alternate%20Logo.png">
   <link rel="manifest" href="site.webmanifest">
   <meta property="og:image" content="assets/Primary%20Logo%20or%20Full%20Logo.png">
   <meta name="twitter:card" content="summary_large_image">

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&amp;display=swap" rel="stylesheet">
   <meta name="description" content="Theo’s Detailing offers professional mobile car detailing that brings the shine to you.">
-  <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
-  <link rel="apple-touch-icon" href="assets/logo.svg">
+  <link rel="icon" type="image/png" href="assets/Secondary%20Logo%20or%20Alternate%20Logo.png">
+  <link rel="apple-touch-icon" href="assets/Secondary%20Logo%20or%20Alternate%20Logo.png">
   <link rel="manifest" href="site.webmanifest">
   <meta property="og:image" content="assets/Primary%20Logo%20or%20Full%20Logo.png">
   <meta name="twitter:card" content="summary_large_image">

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -3,14 +3,14 @@
   "short_name": "Theo's Detailing",
   "icons": [
     {
-      "src": "/assets/logo.svg",
+      "src": "/assets/Secondary%20Logo%20or%20Alternate%20Logo.png",
       "sizes": "192x192",
-      "type": "image/svg+xml"
+      "type": "image/png"
     },
     {
-      "src": "/assets/logo.svg",
+      "src": "/assets/Secondary%20Logo%20or%20Alternate%20Logo.png",
       "sizes": "512x512",
-      "type": "image/svg+xml"
+      "type": "image/png"
     }
   ],
   "start_url": "/",

--- a/styles.css
+++ b/styles.css
@@ -2,12 +2,15 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   font-family: 'Montserrat', Arial, sans-serif;
   background: #f7f9fb;
   color: #222;
-  scroll-behavior: smooth;
 }
 
 img, video {
@@ -16,7 +19,7 @@ img, video {
 }
 
 .logo {
-  height: 60px;
+  height: 70px;
   width: auto;
   max-width: 100%;
 }


### PR DESCRIPTION
## Summary
- apply `scroll-behavior: smooth` globally
- enlarge header and footer logo
- use secondary logo as favicon and manifest icon

## Testing
- `tidy -e index.html`
- `tidy -e 404.html`


------
https://chatgpt.com/codex/tasks/task_e_6882c552acd8832785c37196a4034c04