### PR TITLE
Adjust hero image placement and zoom effect

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -85,7 +85,9 @@ footer .logo {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  object-position: 50% 25%;
+  /* Start the image a bit higher so more of the picture is visible.
+     Content sits around 55% of the image height. */
+  object-position: 50% 55%;
   animation: heroPan 40s ease-in-out infinite;
 }
 
@@ -340,9 +342,29 @@ footer {
 #services, #contact { scroll-margin-top: 80px; }
 
 @keyframes heroPan {
-  0% { transform: scale(1) translateY(-5%); }
-  25% { transform: scale(1.02) translateY(0); }
-  50% { transform: scale(1) translateY(5%); }
-  75% { transform: scale(1.02) translateY(0); }
-  100% { transform: scale(1) translateY(-5%); }
+  /* Start slightly higher on the image */
+  0% {
+    transform: scale(1.2);
+    object-position: 50% 55%;
+  }
+  /* Zoom in dramatically while moving to the top */
+  25% {
+    transform: scale(1.4);
+    object-position: 50% 100%;
+  }
+  /* Zoom back out while dipping to the midpoint (never below 50%) */
+  50% {
+    transform: scale(1.2);
+    object-position: 50% 50%;
+  }
+  /* Return to the top with another zoom */
+  75% {
+    transform: scale(1.4);
+    object-position: 50% 100%;
+  }
+  /* Return to the baseline position */
+  100% {
+    transform: scale(1.2);
+    object-position: 50% 55%;
+  }
 }


### PR DESCRIPTION
## Summary
- position hero photo higher by default so more of the picture is visible
- exaggerate the heroPan animation zoom for a more noticeable effect

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688c4a8312bc83278079af365219e0db