### PR TITLE
Adjust hero animation to spotlight steering wheel

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -85,7 +85,9 @@ footer .logo {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  object-position: 50% 25%;
+  /* Center the framing on the steering wheel which sits
+     roughly 80% of the way up in the image (20% from the top). */
+  object-position: 50% 20%;
   animation: heroPan 40s ease-in-out infinite;
 }
 
@@ -340,9 +342,26 @@ footer {
 #services, #contact { scroll-margin-top: 80px; }
 
 @keyframes heroPan {
-  0% { transform: scale(1) translateY(-5%); }
-  25% { transform: scale(1.02) translateY(0); }
-  50% { transform: scale(1) translateY(5%); }
-  75% { transform: scale(1.02) translateY(0); }
-  100% { transform: scale(1) translateY(-5%); }
+  /* Focus on the steering wheel near the top and
+     gently move between the upper and middle areas */
+  0% {
+    transform: scale(1.3);
+    object-position: 50% 20%;
+  }
+  25% {
+    transform: scale(1.5);
+    object-position: 50% 10%;
+  }
+  50% {
+    transform: scale(1.3);
+    object-position: 50% 50%;
+  }
+  75% {
+    transform: scale(1.5);
+    object-position: 50% 10%;
+  }
+  100% {
+    transform: scale(1.3);
+    object-position: 50% 20%;
+  }
 }


### PR DESCRIPTION
## Summary
- center hero image framing on the steering wheel
- pan between the top and middle while zooming for a smoother effect

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688c4a8312bc83278079af365219e0db